### PR TITLE
Update catalog creation to incorporate help texts

### DIFF
--- a/tools/all_questions.xml
+++ b/tools/all_questions.xml
@@ -2499,7 +2499,7 @@ Ebenso wie bei den Formaten gilt hier: je standardisierter, offener und etablier
 		<is_collection>False</is_collection>
 		<order>5</order>
     <help lang="en">A metadata editor is suitable for this.</help>
-    <help lang="de">Dafür bietet sich ein Metadateneditor an.<help/>
+    <help lang="de">Dafür bietet sich ein Metadateneditor an.</help>
 		<text lang="en">Which metadata are collected manually?</text>
 		<text lang="de">Welche Metadaten werden manuell erhoben?</text>
 		<verbose_name lang="en"/>
@@ -4221,7 +4221,7 @@ Weitere relevante Schutzrechte können gewerbliche Schutzrechte wie Patente, Geb
 		<path>ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/embargo_period"/>
-		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets"/(Diese Frage stammt ursprünglich aus dem Horizon 2020 FAIR Datenmanagementplan.)>
+		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>8</order>
 		<help lang="en"/>

--- a/tools/all_questions.xml
+++ b/tools/all_questions.xml
@@ -4221,7 +4221,7 @@ Weitere relevante Schutzrechte können gewerbliche Schutzrechte wie Patente, Geb
 		<path>ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period</path>
 		<dc:comment/>
 		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/embargo_period"/>
-    <questionset dc:uri="https://rdmorganiser.github.io/terms/questions/ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>8</order>
 		<help lang="en"/>

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -5,11 +5,12 @@ from copy import deepcopy
 from lxml import etree
 from lxml.etree import Element
 
+
 def main():
     root = read_xml("all_questions.xml")
     life_cycle_content = read_yaml("cat_member.yaml")
     cat_list = []
-    cat_list_tmp = []
+    # cat_list_tmp = []  # TODO this variable is unused
     for cat_vars in life_cycle_content["catalogs"]:
         cat_list.append(make_root(cat_vars))
 
@@ -32,8 +33,8 @@ def main():
             # use path as key for check of membership to catalog
             if life_cycle_content[question.find("path").text][cat_info[0]]:
                 # check if qset and sec are already in catalog
-                if cat_list[n].find(qset_xpath, xml_nsmap) == None:
-                    if cat_list[n].find(sec_xpath, xml_nsmap) == None:
+                if cat_list[n].find(qset_xpath, xml_nsmap) is None:
+                    if cat_list[n].find(sec_xpath, xml_nsmap) is None:
                         tmp_sec = change_path(sec, cat_info[0])
                         cat_list[n].append(deepcopy(tmp_sec))
                     tmp_qset = change_path(qset, cat_info[0])
@@ -49,13 +50,15 @@ def main():
     write_catalogs(cat_list, life_cycle_content["catalogs"])
     change_uri(life_cycle_content["catalogs"])
 
+
 def write_catalogs(cat_list, name_list):
-    # takes a list of root elements and file names and writes them to the specified
-    # relative directory
+    # takes a list of root elements and file names and writes them to the
+    # specified relative directory
     for n, cat in enumerate(cat_list):
         tree = etree.ElementTree(cat)
         tree.write("../rdmorganiser/questions/" + name_list[n][0] + ".xml",
-                    xml_declaration=True, encoding="UTF-8")
+                   xml_declaration=True, encoding="UTF-8")
+
 
 def change_path(element, name):
     # takes an etree.Element and catalog key and changes the path variable of
@@ -67,9 +70,10 @@ def change_path(element, name):
     path.text = name + path.text
     return element
 
+
 def change_uri(name_list):
-    # this is rather a workaround than a solution, but prefixes on Attributes make things
-    # unnecessary hard to access and change
+    # this is rather a workaround than a solution, but prefixes on Attributes
+    # make things unnecessary hard to access and change
     default_uri = "https://rdmorganiser.github.io/terms/questions/ua_ruhr"
     for name in name_list:
         cat = open("../rdmorganiser/questions/" + name[0] + ".xml", "r", encoding="UTF-8")
@@ -82,13 +86,14 @@ def change_uri(name_list):
             cat.write(line)
         cat.close()
 
+
 def make_root(cat_vars):
-    # takes a list of catalog variables [key, name] and generates a root element
-    # with a predefined name space among other informations
+    # takes a list of catalog variables [key, name] and generates a
+    # root element with a predefined name space among other information
     XHTML_NAMESPACE = "http://purl.org/dc/elements/1.1/"
-    XHTML = "{%s}" % XHTML_NAMESPACE
-    NSMAP = {"dc":XHTML_NAMESPACE} # the default namespace with prefix
-    root = etree.Element("rdmo", nsmap=NSMAP) # lxml only!
+    # XHTML = "{%s}" % XHTML_NAMESPACE  # TODO this variable is unused
+    NSMAP = {"dc": XHTML_NAMESPACE}  # the default namespace with prefix
+    root = etree.Element("rdmo", nsmap=NSMAP)  # lxml only!
     root.append(etree.fromstring("""
         <catalog xmlns:dc="http://purl.org/dc/elements/1.1/" dc:uri="https://rdmorganiser.github.io/terms/questions/ua-ruhr">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
@@ -104,17 +109,20 @@ def make_root(cat_vars):
     root[0][5].text = cat_vars[2]
     return root
 
+
 def read_yaml(file_name):
     # reads in a yaml file and returns the content of it
     data_file = open(os.path.abspath(file_name), "r")
     content = yaml.safe_load(data_file)
     return content
 
+
 def read_xml(file_name):
     # reads in a xml file and returns it as etree.Element
     tree = etree.parse(os.path.abspath(file_name))
     root = tree.getroot()
     return root
+
 
 if __name__ == "__main__":
     main()

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -35,17 +35,22 @@ def main():
         sec_xpath = ".section[@dc:uri='" + sec_uri + "']"
         sec = root.find(sec_xpath, xml_nsmap)
 
-        for n, cat_info in enumerate(life_cycle_content["catalogs"]):
+        for n, catalog_info in enumerate(life_cycle_content["catalogs"]):
             # use path as key for check of membership to catalog
-            if life_cycle_content[question.find("path").text][cat_info[0]]:
+            # print(n, cat_info)
+            # print(question.find("path").text)
+            # print(life_cycle_content[question.find("path").text])
+            # print("\n\n")
+            catalog_key = catalog_info["key"]
+            if life_cycle_content[question.find("path").text][catalog_key]:
                 # check if qset and sec are already in catalog
                 if cat_list[n].find(qset_xpath, xml_nsmap) is None:
                     if cat_list[n].find(sec_xpath, xml_nsmap) is None:
-                        tmp_sec = change_path(sec, cat_info[0])
+                        tmp_sec = change_path(sec, catalog_key)
                         cat_list[n].append(deepcopy(tmp_sec))
-                    tmp_qset = change_path(qset, cat_info[0])
+                    tmp_qset = change_path(qset, catalog_key)
                     cat_list[n].append(deepcopy(tmp_qset))
-                tmp_question = change_path(question, cat_info[0])
+                tmp_question = change_path(question, catalog_key)
                 # sort the questions below their respective questionsets
                 cat_qset = cat_list[n].find(qset_xpath, xml_nsmap)
                 index = cat_list[n].index(cat_qset)
@@ -63,7 +68,7 @@ def write_catalogs(cat_list, name_list):
     for n, cat in enumerate(cat_list):
         tree = etree.ElementTree(cat)
         tree.write(
-            "../rdmorganiser/questions/" + name_list[n][0] + ".xml",
+            "../rdmorganiser/questions/" + name_list[n]["key"] + ".xml",
             xml_declaration=True,
             encoding="UTF-8",
         )
@@ -84,23 +89,23 @@ def change_uri(name_list):
     # this is rather a workaround than a solution, but prefixes on Attributes
     # make things unnecessary hard to access and change
     default_uri = "https://rdmorganiser.github.io/terms/questions/ua_ruhr"
-    for name in name_list:
+    for catalog in name_list:
         cat = open(
-            "../rdmorganiser/questions/" + name[0] + ".xml", "r", encoding="UTF-8"
+            "../rdmorganiser/questions/" + catalog["key"] + ".xml", "r", encoding="UTF-8"
         )
         lines = cat.readlines()
         cat.close()
         cat = open(
-            "../rdmorganiser/questions/" + name[0] + ".xml", "w", encoding="UTF-8"
+            "../rdmorganiser/questions/" + catalog["key"] + ".xml", "w", encoding="UTF-8"
         )
         for line in lines:
             if default_uri in line:
-                line = line.replace("ua_ruhr", name[0])
+                line = line.replace("ua_ruhr", catalog["key"])
             cat.write(line)
         cat.close()
 
 
-def make_root(cat_vars):
+def make_root(catalog_vars):
     # takes a list of catalog variables [key, name] and generates a
     # root element with a predefined name space among other information
     XHTML_NAMESPACE = "http://purl.org/dc/elements/1.1/"
@@ -121,9 +126,12 @@ def make_root(cat_vars):
         """
         )
     )
-    root[0][1].text = cat_vars[0]
-    root[0][4].text = cat_vars[1]
-    root[0][5].text = cat_vars[2]
+
+    root[0][1].text = catalog_vars["key"]
+    root[0][4].text = catalog_vars["title_en"]
+    root[0][5].text = catalog_vars["title_de"]
+    for r in root:
+        print(list(r))
     return root
 
 

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -133,7 +133,7 @@ def make_root(catalog_vars):
     )
 
     root[0][1].text = catalog_vars["key"]
-    root[0][2].text = catalog_vars["help_text"]
+    root[0][2].text = catalog_vars["help_text_en"]
     root[0][4].text = catalog_vars["title_en"]
     root[0][5].text = catalog_vars["title_de"]
     for r in root:

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -43,7 +43,7 @@ def main():
                 # sort the questions below their respective questionsets
                 cat_qset = cat_list[n].find(qset_xpath, xml_nsmap)
                 index = cat_list[n].index(cat_qset)
-                cat_list[n].insert(index+1, deepcopy(tmp_question))
+                cat_list[n].insert(index + 1, deepcopy(tmp_question))
             else:
                 continue
 
@@ -56,8 +56,11 @@ def write_catalogs(cat_list, name_list):
     # specified relative directory
     for n, cat in enumerate(cat_list):
         tree = etree.ElementTree(cat)
-        tree.write("../rdmorganiser/questions/" + name_list[n][0] + ".xml",
-                   xml_declaration=True, encoding="UTF-8")
+        tree.write(
+            "../rdmorganiser/questions/" + name_list[n][0] + ".xml",
+            xml_declaration=True,
+            encoding="UTF-8",
+        )
 
 
 def change_path(element, name):
@@ -76,10 +79,14 @@ def change_uri(name_list):
     # make things unnecessary hard to access and change
     default_uri = "https://rdmorganiser.github.io/terms/questions/ua_ruhr"
     for name in name_list:
-        cat = open("../rdmorganiser/questions/" + name[0] + ".xml", "r", encoding="UTF-8")
+        cat = open(
+            "../rdmorganiser/questions/" + name[0] + ".xml", "r", encoding="UTF-8"
+        )
         lines = cat.readlines()
         cat.close()
-        cat = open("../rdmorganiser/questions/" + name[0] + ".xml", "w", encoding="UTF-8")
+        cat = open(
+            "../rdmorganiser/questions/" + name[0] + ".xml", "w", encoding="UTF-8"
+        )
         for line in lines:
             if default_uri in line:
                 line = line.replace("ua_ruhr", name[0])
@@ -94,7 +101,9 @@ def make_root(cat_vars):
     # XHTML = "{%s}" % XHTML_NAMESPACE  # TODO this variable is unused
     NSMAP = {"dc": XHTML_NAMESPACE}  # the default namespace with prefix
     root = etree.Element("rdmo", nsmap=NSMAP)  # lxml only!
-    root.append(etree.fromstring("""
+    root.append(
+        etree.fromstring(
+            """
         <catalog xmlns:dc="http://purl.org/dc/elements/1.1/" dc:uri="https://rdmorganiser.github.io/terms/questions/ua-ruhr">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key></key>
@@ -103,7 +112,9 @@ def make_root(cat_vars):
 		<title lang="en"></title>
 		<title lang="de"></title>
 	    </catalog>
-        """))
+        """
+        )
+    )
     root[0][1].text = cat_vars[0]
     root[0][4].text = cat_vars[1]
     root[0][5].text = cat_vars[2]

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -3,14 +3,20 @@ import os
 import yaml
 from copy import deepcopy
 from lxml import etree
-from lxml.etree import Element
+# from lxml.etree import Element
 
 
 def main():
+    # Read XML catalog containing all files
     root = read_xml("all_questions.xml")
+
+    # Read in definitions for derived catalogs
+    # This contains catalog names under the 'catalogs'
+    # keyword and an entry for each attribute containing
+    # a boolean flag for each catalog key in the 'catalogs' list
     life_cycle_content = read_yaml("cat_member.yaml")
+
     cat_list = []
-    # cat_list_tmp = []  # TODO this variable is unused
     for cat_vars in life_cycle_content["catalogs"]:
         cat_list.append(make_root(cat_vars))
 

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -128,6 +128,7 @@ def make_root(catalog_vars):
     )
 
     root[0][1].text = catalog_vars["key"]
+    root[0][2].text = catalog_vars["help_text"]
     root[0][4].text = catalog_vars["title_en"]
     root[0][5].text = catalog_vars["title_de"]
     for r in root:

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -3,6 +3,7 @@ import os
 import yaml
 from copy import deepcopy
 from lxml import etree
+
 # from lxml.etree import Element
 
 
@@ -91,12 +92,16 @@ def change_uri(name_list):
     default_uri = "https://rdmorganiser.github.io/terms/questions/ua_ruhr"
     for catalog in name_list:
         cat = open(
-            "../rdmorganiser/questions/" + catalog["key"] + ".xml", "r", encoding="UTF-8"
+            "../rdmorganiser/questions/" + catalog["key"] + ".xml",
+            "r",
+            encoding="UTF-8",
         )
         lines = cat.readlines()
         cat.close()
         cat = open(
-            "../rdmorganiser/questions/" + catalog["key"] + ".xml", "w", encoding="UTF-8"
+            "../rdmorganiser/questions/" + catalog["key"] + ".xml",
+            "w",
+            encoding="UTF-8",
         )
         for line in lines:
             if default_uri in line:

--- a/tools/auto_catalog_creation.py
+++ b/tools/auto_catalog_creation.py
@@ -136,8 +136,7 @@ def make_root(catalog_vars):
     root[0][2].text = catalog_vars["help_text_en"]
     root[0][4].text = catalog_vars["title_en"]
     root[0][5].text = catalog_vars["title_de"]
-    for r in root:
-        print(list(r))
+
     return root
 
 

--- a/tools/cat_member.yaml
+++ b/tools/cat_member.yaml
@@ -1,17 +1,22 @@
 catalogs:
 - key: ua_ruhr
+  help_text: In diesem Katalog sind alle Fragen enthalten. Er behandelt umfassend die verschiedenen Aspekte des Forschungsdatenmanagements, deckt Anforderungen verschiedener Disziplinen ab, und ist daher recht umfangreich. Nutzen Sie diesen Katalog, wenn Sie die Datenhaltung im Team oder Verbund organisieren möchten.
   title_en: UA Ruhr
   title_de: UA Ruhr
 - key: consultation
+  help_text: Sie benötigen eine Beratung zur Erstellung eines Datenmanagenentplans oder allgemein zu Ihrem FDM? Füllen Sie diesen Katalog aus, und kontaktieren Sie uns.
   title_en: UA Ruhr-Consultation
   title_de: UA Ruhr-Beratung
 - key: proposal
+  help_text: Fördergeber fordern im Antrag immer mehr Informationen zum Umgang mit Ihren Forschungsdaten. Nutzen Sie diesen Katalog, wenn Sie Ihr Datenmanagement für einen Antrag dokumentieren wollen.
   title_en: UA Ruhr-Proposal
   title_de: UA Ruhr-Antragsstellung
 - key: archive
+  help_text: Nutzen Sie diesen Katalog, wenn Sie planen die Daten in einem zentralen Speicher, Archiv oder Repositorium abzulegen. Neben Fragen zur Datenspeicherung werden auch einige allgemeine Projektinformationen abgefragt, die zum Beispiel für gängige Metadatenstandards relevant sind.
   title_en: UA Ruhr-Archive
   title_de: UA Ruhr-Archivierung
 - key: training
+  help_text: Dieser Katalog kann ergänzend zum Moodle-Kurs &lt;a href="https://moodle.ruhr-uni-bochum.de/m/course/view.php?id=19338" target="_blank"&gt;“Forschungsdaten managen”&lt;/a&gt; ausgefüllt werden. Er umfasst grundlegende Fragen zur Organisation, Dokumentation, Archivierung und Publikation von Forschungsdaten.
   title_en: UA Ruhr-Training
   title_de: UA Ruhr-Schulung
 ua_ruhr/general/topic-research_question/title:

--- a/tools/cat_member.yaml
+++ b/tools/cat_member.yaml
@@ -1,19 +1,19 @@
 catalogs:
-- - ua_ruhr
-  - UA Ruhr
-  - UA Ruhr
-- - consultation
-  - UA Ruhr-Consultation
-  - UA Ruhr-Beratung
-- - proposal
-  - UA Ruhr-Proposal
-  - UA Ruhr-Antragsstellung
-- - archive
-  - UA Ruhr-Archive
-  - UA Ruhr-Archivierung
-- - training
-  - UA Ruhr-Training
-  - UA Ruhr-Schulung
+- key: ua_ruhr
+  title_en: UA Ruhr
+  title_de: UA Ruhr
+- key: consultation
+  title_en: UA Ruhr-Consultation
+  title_de: UA Ruhr-Beratung
+- key: proposal
+  title_en: UA Ruhr-Proposal
+  title_de: UA Ruhr-Antragsstellung
+- key: archive
+  title_en: UA Ruhr-Archive
+  title_de: UA Ruhr-Archivierung
+- key: training
+  title_en: UA Ruhr-Training
+  title_de: UA Ruhr-Schulung
 ua_ruhr/general/topic-research_question/title:
   ua_ruhr: true
   consultation: true

--- a/tools/cat_member.yaml
+++ b/tools/cat_member.yaml
@@ -1,22 +1,27 @@
 catalogs:
 - key: ua_ruhr
-  help_text: In diesem Katalog sind alle Fragen enthalten. Er behandelt umfassend die verschiedenen Aspekte des Forschungsdatenmanagements, deckt Anforderungen verschiedener Disziplinen ab, und ist daher recht umfangreich. Nutzen Sie diesen Katalog, wenn Sie die Datenhaltung im Team oder Verbund organisieren möchten.
+  help_text_en: This catalog contains all questions and covers all relevant aspects of research data management including some domain-specific questions and is therefore rather extensive. Use this catalog if you want to organize the data management of a collaborative project or facility.
+  help_text_de: In diesem Katalog sind alle Fragen enthalten. Er behandelt umfassend die verschiedenen Aspekte des Forschungsdatenmanagements, deckt Anforderungen verschiedener Disziplinen ab, und ist daher recht umfangreich. Nutzen Sie diesen Katalog, wenn Sie die Datenhaltung im Team oder Verbund organisieren möchten.
   title_en: UA Ruhr
   title_de: UA Ruhr
 - key: consultation
-  help_text: Sie benötigen eine Beratung zur Erstellung eines Datenmanagenentplans oder allgemein zu Ihrem FDM? Füllen Sie diesen Katalog aus, und kontaktieren Sie uns.
+  help_text_en: Do you need advice on creating a data management plan or on your RDM in general? Fill out this catalog and contact *your local RDM-Team* (&lt;a href="https://www.ruhr-uni-bochum.de/researchdata/de/contact.html" target="_blank"&gt;RUB&lt;/a&gt; / &lt;a href="https://forschungsfoerderung.tu-dortmund.de/forschungsdatenmanagement/beratungsangebot/" target="_blank"&gt;TUDO&lt;/a&gt; / &lt;a href="https://www.uni-due.de/rds/kontakt_formular.php" target="_blank"&gt;UDE&lt;/a&gt;).
+  help_text_de: Sie benötigen eine Beratung zur Erstellung eines Datenmanagenentplans oder allgemein zu Ihrem FDM? Füllen Sie diesen Katalog aus, und kontaktieren Sie *ihr lokales FDM-Team* (&lt;a href="https://www.ruhr-uni-bochum.de/researchdata/de/contact.html" target="_blank"&gt;RUB&lt;/a&gt; / &lt;a href="https://forschungsfoerderung.tu-dortmund.de/forschungsdatenmanagement/beratungsangebot/" target="_blank"&gt;TUDO&lt;/a&gt; / &lt;a href="https://www.uni-due.de/rds/kontakt_formular.php" target="_blank"&gt;UDE&lt;/a&gt;).
   title_en: UA Ruhr-Consultation
   title_de: UA Ruhr-Beratung
 - key: proposal
-  help_text: Fördergeber fordern im Antrag immer mehr Informationen zum Umgang mit Ihren Forschungsdaten. Nutzen Sie diesen Katalog, wenn Sie Ihr Datenmanagement für einen Antrag dokumentieren wollen.
+  help_text_en: Funding agencies are demanding more and more information on the handling of research data. Use this catalog if you want to document your data management for a grant application.
+  help_text_de: Fördergeber fordern im Antrag immer mehr Informationen zum Umgang mit Ihren Forschungsdaten. Nutzen Sie diesen Katalog, wenn Sie Ihr Datenmanagement für einen Antrag dokumentieren wollen.
   title_en: UA Ruhr-Proposal
   title_de: UA Ruhr-Antragsstellung
 - key: archive
-  help_text: Nutzen Sie diesen Katalog, wenn Sie planen die Daten in einem zentralen Speicher, Archiv oder Repositorium abzulegen. Neben Fragen zur Datenspeicherung werden auch einige allgemeine Projektinformationen abgefragt, die zum Beispiel für gängige Metadatenstandards relevant sind.
+  help_text_en: Use this catalog if you plan to store the data in a central repository or archive. In addition to questions about data storage the catalog also contains some general project questions which are relevant, for example, to common meta data standards.
+  help_text_de: Nutzen Sie diesen Katalog, wenn Sie planen die Daten in einem zentralen Speicher, Archiv oder Repositorium abzulegen. Neben Fragen zur Datenspeicherung werden auch einige allgemeine Projektinformationen abgefragt, die zum Beispiel für gängige Metadatenstandards relevant sind.
   title_en: UA Ruhr-Archive
   title_de: UA Ruhr-Archivierung
 - key: training
-  help_text: Dieser Katalog kann ergänzend zum Moodle-Kurs &lt;a href="https://moodle.ruhr-uni-bochum.de/m/course/view.php?id=19338" target="_blank"&gt;“Forschungsdaten managen”&lt;/a&gt; ausgefüllt werden. Er umfasst grundlegende Fragen zur Organisation, Dokumentation, Archivierung und Publikation von Forschungsdaten.
+  help_text_en: 'This catalog complements the Moodle course “Research Data Management” (&lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;RUB Course&lt;/a&gt; / &lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;UDE Course&lt;/a&gt; (PW: forschung)). It contains basic questions about organizing, documenting, archiving and publishing research data.'
+  help_text_de: 'Dieser Katalog kann ergänzend zum Moodle-Kurs “Forschungsdaten managen” (&lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;RUB-Kurs&lt;/a&gt; / &lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;UDE-Kurs&lt;/a&gt; (PW: forschung)) ausgefüllt werden. Er umfasst grundlegende Fragen zur Organisation, Dokumentation, Archivierung und Publikation von Forschungsdaten.'
   title_en: UA Ruhr-Training
   title_de: UA Ruhr-Schulung
 ua_ruhr/general/topic-research_question/title:

--- a/tools/cat_member.yaml
+++ b/tools/cat_member.yaml
@@ -91,8 +91,8 @@ ua_ruhr/general/funding-funder/title:
   consultation: false
   proposal: true
   archive: false
+  training: true
 ua_ruhr/general/funding-funder/funder_policy:
-  training: true 
   ua_ruhr: true
   consultation: false
   proposal: true

--- a/tools/cat_member.yaml
+++ b/tools/cat_member.yaml
@@ -11,7 +11,7 @@ catalogs:
 - - archive
   - UA Ruhr-Archive
   - UA Ruhr-Archivierung
-- - training 
+- - training
   - UA Ruhr-Training
   - UA Ruhr-Schulung
 ua_ruhr/general/topic-research_question/title:
@@ -19,73 +19,73 @@ ua_ruhr/general/topic-research_question/title:
   consultation: true
   proposal: true
   archive: true
-  training: true 
+  training: true
 ua_ruhr/general/topic-research_question/keywords:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/general/topic-research_field/research_field:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/general/topic-research_field/name:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/general/project-schedule-schedule/project_start:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/general/project-schedule-schedule/project_end:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/general/project-schedule-schedule/project_duration:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/general/project-partners-name/name:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/general/project-partners-partner/name:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/general/project-partners-partner/rdm_policy:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/general/project-partners-partner/contact:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/general/funding-funder/name:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: true 
+  training: true
 ua_ruhr/general/funding-funder/title:
   ua_ruhr: true
   consultation: false
@@ -97,694 +97,694 @@ ua_ruhr/general/funding-funder/funder_policy:
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/general/other-requirements-yesno/abstract:
   ua_ruhr: true
   consultation: true
   proposal: false
   archive: false
-  training: true 
+  training: true
 ua_ruhr/general/other-requirements-yesno/yesno:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: true 
+  training: true
 ua_ruhr/general/other-requirements-requirements/requirements:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: true 
+  training: true
 ua_ruhr/content-classification/data-dataset/description:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: true 
+  training: true
 ua_ruhr/content-classification/data-existing_data/origin:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/content-classification/data-existing_data/creator_name:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/content-classification/data-existing_data/uri:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/content-classification/data-reuse:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/content-classification/data-reuse/scenario:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: true 
+  training: true
 ua_ruhr/content-classification/data-reproducibility/reproducibility:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: true 
+  training: true
 ua_ruhr/technical-classification/data-dates/data_collection_start:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-dates/data_collection_end:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-dates/data_cleansing_start:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-dates/data_cleansing_end:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-dates/data_analysis_start:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-dates/data_analysis_end:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-volume/volume:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-volume/rate:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-formats/format:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: true 
+  training: true
 ua_ruhr/technical-classification/data-tools/creation_methods:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-tools/usage_technology:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-tools/documentation:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-versioning/yesno:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/technical-classification/data-versioning/strategy:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: true 
+  training: true
 ua_ruhr/technical-classification/data-versioning/tool:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/scenarios-usage/description:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/scenarios-usage/frequency:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/scenarios-usage/infrastructure:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/scenarios-usage/support:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-storage-and-security-storage/type:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-storage-and-security-storage/uri:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-storage-and-security-storage/organisation_policy:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-storage-and-security-storage/naming_policy:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-storage-and-security-data_security/access_permissions:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-storage-and-security-data_security/backups:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: true 
+  training: true
 ua_ruhr/data-usage/data-storage-and-security-data_security/name:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-storage-and-security-data_security/security_measures:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-sharing-and-re-use-interoperability/interoperability:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-sharing-and-re-use-interoperability/abstract:
   ua_ruhr: true
   consultation: true
   proposal: false
   archive: false
-  training: true 
+  training: true
 ua_ruhr/data-usage/data-sharing-and-re-use-publication/yesno:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: true 
+  training: true
 ua_ruhr/data-usage/data-sharing-and-re-use-publication/explanation:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-sharing-and-re-use-publication/conditions:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-sharing-and-re-use-publication/restrictions_explanation:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/data-sharing-and-re-use-publication/data_publication_date:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/collaborative-work-collaboration/yesno:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/collaborative-work-collaboration/tools:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/collaborative-work-collaboration/organisation:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/quality-assurance-dataset/measures:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/quality-assurance-integration/integration:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/costs-dataset/creation_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/costs-dataset/creation_non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/costs-dataset/usage_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/costs-dataset/usage_non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/costs-dataset/storage_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/data-usage/costs-dataset/storage_non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata/abstract:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-dataset/scope:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: true 
+  training: true
 ua_ruhr/metadata-and-referencing/metadata-dataset/abstract:
   ua_ruhr: true
   consultation: true
   proposal: false
   archive: false
-  training: true 
+  training: true
 ua_ruhr/metadata-and-referencing/metadata-dataset/standards:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-dataset/creation_automatic:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-dataset/mappings:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-dataset/creation_semi_automatic:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-dataset/creation_manual:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-dataset/quality_assurance:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: true
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-dataset/responsible_person:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-costs/personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/metadata-costs/non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/structure-granularity-and-referencing-structure/structure:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: true 
+  training: true
 ua_ruhr/metadata-and-referencing/structure-granularity-and-referencing-pids/yesno:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/structure-granularity-and-referencing-pids/system:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/structure-granularity-and-referencing-pids/subentities:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/structure-granularity-and-referencing-pids/name:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/structure-granularity-and-referencing-costs/personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/metadata-and-referencing/structure-granularity-and-referencing-costs/non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/general-legal-issues-international_yesno/international_yesno:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-personal_data_yesno/yesno:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-privacy_law/privacy_law:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-personal_data/bdsg_3_9:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-personal_data/anonymization:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-personal_data/extent:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-personal_data/statement:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-personal_data/record:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-personal_data/deletion:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-other/yesno:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-other/description:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-costs/anonymization_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-costs/anonymization_non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-costs/security_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-costs/security_non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-official_approval/ethics_committee:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-official_approval/yesno:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-official_approval/title:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-official_approval/agency:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/sensitive-data-official_approval/data_access_committee:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/intellectual-property-rights-yesno/yesno:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/intellectual-property-rights-dataset/copyrights:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/intellectual-property-rights-dataset/other_rights:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/intellectual-property-rights-dataset/owner:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/intellectual-property-rights-costs/personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/legal-and-ethics/intellectual-property-rights-costs/non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/selection-criteria/selection_criteria:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/selection-criteria/responsible_person:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/yesno:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/purpose:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/duration:
   ua_ruhr: true
   consultation: true
   proposal: true
   archive: true
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/reuse_duration:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/repository:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: true 
+  training: true
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/certification:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/repository_arrangements:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/embargo_period:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/access_authentication:
   ua_ruhr: true
   consultation: false
   proposal: false
   archive: true
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/data_archiving_date:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-costs/personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-costs/non_personnel:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false
 ua_ruhr/storage-and-long-term-preservation/long-term-preservation-costs/cover_how:
   ua_ruhr: true
   consultation: false
   proposal: true
   archive: false
-  training: false 
+  training: false


### PR DESCRIPTION
Fixes #78

This PR refactors catalog derivation and adds help texts to the catalogs.

To achieve this, this PR changes the catalogs entry of `cat_member.yaml` to be a list of dictionaries. These could possibly be structured better, but the current solution allowed to keep most of the existing code intact.

A major limitation is, that the comment field used for the help texts does not support support multiple languages yet. I might have missed an option to resolve this, but the upstream catalogs look similar to what we do now. This PR now uses the German help texts. However, using the English ones might be preferable.

To get my head into the code I did some refactoring and applied some PEP8 style stuff. I hope I have not violated any coding convention by this. 