### PR TITLE
Correct training catalog help url to RUB moodle course

### DIFF
--- a/tools/cat_member.yaml
+++ b/tools/cat_member.yaml
@@ -20,8 +20,8 @@ catalogs:
   title_en: UA Ruhr-Archive
   title_de: UA Ruhr-Archivierung
 - key: training
-  help_text_en: 'This catalog complements the Moodle course “Research Data Management” (&lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;RUB Course&lt;/a&gt; / &lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;UDE Course&lt;/a&gt; (PW: forschung)). It contains basic questions about organizing, documenting, archiving and publishing research data.'
-  help_text_de: 'Dieser Katalog kann ergänzend zum Moodle-Kurs “Forschungsdaten managen” (&lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;RUB-Kurs&lt;/a&gt; / &lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;UDE-Kurs&lt;/a&gt; (PW: forschung)) ausgefüllt werden. Er umfasst grundlegende Fragen zur Organisation, Dokumentation, Archivierung und Publikation von Forschungsdaten.'
+  help_text_en: 'This catalog complements the Moodle course “Research Data Management” (&lt;a href="https://moodle.ruhr-uni-bochum.de/m/course/view.php?id=19338&section=0&lang=en" target="_blank"&gt;RUB Course&lt;/a&gt; / &lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;UDE Course&lt;/a&gt; (PW: forschung)). It contains basic questions about organizing, documenting, archiving and publishing research data.'
+  help_text_de: 'Dieser Katalog kann ergänzend zum Moodle-Kurs “Forschungsdaten managen” (&lt;a href="https://moodle.ruhr-uni-bochum.de/m/course/view.php?id=19338" target="_blank"&gt;RUB-Kurs&lt;/a&gt; / &lt;a href="https://moodle.uni-due.de/course/view.php?id=20309" target="_blank"&gt;UDE-Kurs&lt;/a&gt; (PW: forschung)) ausgefüllt werden. Er umfasst grundlegende Fragen zur Organisation, Dokumentation, Archivierung und Publikation von Forschungsdaten.'
   title_en: UA Ruhr-Training
   title_de: UA Ruhr-Schulung
 ua_ruhr/general/topic-research_question/title:


### PR DESCRIPTION
Changes proposed in this pull request:
* Correct training catalog help url to RUB moodle course

@FDM-UARuhr/Reviewers

