### PR TITLE
Add new attributes about permanent project owner

### DIFF
--- a/rdmorganiser/domain/rdmo.xml
+++ b/rdmorganiser/domain/rdmo.xml
@@ -1498,4 +1498,18 @@
 	  <dc:comment>Refers to the place of publication which must be distinguished from the place of storaging and archiving see rdmorganiser#55</dc:comment>
 	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing"/>
 	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person/name">
+	  <uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	  <key>responsible_person_name</key>
+	  <path>project/dataset/preservation/responsible_person/name</path>
+	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
+	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person/email">
+	  <uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	  <key>responsible_person_email</key>
+	  <path>project/dataset/preservation/responsible_person/email</path>
+	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
+	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing"/>
+	</attribute>
 </rdmo>

--- a/rdmorganiser/domain/rdmo.xml
+++ b/rdmorganiser/domain/rdmo.xml
@@ -1503,13 +1503,20 @@
 	  <key>responsible_person_name</key>
 	  <path>project/dataset/preservation/responsible_person/name</path>
 	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
-	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing"/>
+	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person"/>
 	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person/email">
 	  <uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 	  <key>responsible_person_email</key>
 	  <path>project/dataset/preservation/responsible_person/email</path>
 	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
-	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/sharing"/>
+	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person"/>
+	</attribute>
+	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person">
+	  <uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+	  <key>responsible_person</key>
+	  <path>project/dataset/preservation/responsible_person</path>
+	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
+	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation"/>
 	</attribute>
 </rdmo>


### PR DESCRIPTION
Fixes #97

In #65 we proposed to add new questions about the name and email address of the permanent project owner/data owner. The two new questions were already implemented in [rdmorganiser/questions/rdmo.xml](https://github.com/FDM-UARuhr/rdmo-catalog-uaruhr/blob/add-new-attributes/rdmorganiser/questions/rdmo.xml) via #75. This PR adds the related attributes `project/dataset/preservation/responsible_person/name` and `project/dataset/preservation/responsible_person/email` to [rdmorganiser/domain/rdmo.xml](https://github.com/FDM-UARuhr/rdmo-catalog-uaruhr/blob/add-new-attributes/rdmorganiser/domain/rdmo.xml). 




