### PR TITLE
Change question about permanent data contact person

### DIFF
--- a/rdmorganiser/domain/rdmo.xml
+++ b/rdmorganiser/domain/rdmo.xml
@@ -1500,23 +1500,23 @@
 	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person/name">
 	  <uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-	  <key>responsible_person_name</key>
+	  <key>name</key>
 	  <path>project/dataset/preservation/responsible_person/name</path>
-	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
+	  <dc:comment>Refers to the permanent project owner: see https://github.com/rdmorganiser/rdmo-catalog/issues/110</dc:comment>
 	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person"/>
 	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person/email">
 	  <uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
-	  <key>responsible_person_email</key>
+	  <key>email</key>
 	  <path>project/dataset/preservation/responsible_person/email</path>
-	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
+	  <dc:comment>Refers to the permanent project owner: see https://github.com/rdmorganiser/rdmo-catalog/issues/110</dc:comment>
 	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person"/>
 	</attribute>
 	<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person">
 	  <uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 	  <key>responsible_person</key>
 	  <path>project/dataset/preservation/responsible_person</path>
-	  <dc:comment>Refers to the permanent project owner see #65</dc:comment>
+	  <dc:comment>Refers to the permanent project owner: see https://github.com/rdmorganiser/rdmo-catalog/issues/110</dc:comment>
 	  <parent dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation"/>
 	</attribute>
 </rdmo>

--- a/rdmorganiser/questions/rdmo.xml
+++ b/rdmorganiser/questions/rdmo.xml
@@ -5602,6 +5602,82 @@ Weitere relevante Schutzrechte können gewerbliche Schutzrechte wie Patente, Geb
 		<optionsets/>
 		<conditions/>
 	</question>
+	<question dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/storage-and-long-term-preservation/long-term-preservation-datasets/responsible_person_name">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>responsible_person_name</key>
+		<path>rdmo/storage-and-long-term-preservation/long-term-preservation-datasets/responsible_person_name</path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person/name"/>
+		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<is_collection>False</is_collection>
+		<order>11</order>
+		<help lang="en">Examples of these decisions include data access and authorization, the optimization of storage space after a certain retention period, or the transfer of authority to a new contact person.
+
+Such decisions are necessary, for example, in the event of a loss of access data, a new access request or the departure of the previous contact person.</help>
+		<text lang="en">Who is the long-term contact person who can make decisions about the data? Please specify the name.</text>
+		<verbose_name lang="en"/>
+		<verbose_name_plural lang="en"/>
+		<help lang="de">Beispiele hierfür sind die Vergabe von Zugangsdaten/Zugangsberechtigungen, die Optimierung des Speicherplatzes nach einer gewissen Aufbewahrungsfrist oder die Übergabe der Befugnisse an einen neuen Ansprechpartner.
+
+Solche Entscheidungen sind beispielsweise bei einem Verlust von Zugangsdaten, bei einer neuen Zugangsanfrage oder beim Ausscheiden des bisherigen Ansprechpartners erforderlich.</help>
+		<text lang="de">Wer ist der langfristige Ansprechpartner, der über die Daten entscheiden kann? Bitte geben Sie den Name an.</text>
+		<verbose_name lang="de"/>
+		<verbose_name_plural lang="de"/>
+		<help lang="fr">Exemples de telles decisions sont l'attribution d'un compte / de permis d'accès, la rationalisation de l'espace d'archiviation après un délai de garde défini, le transfert de l'autorité à un autre référent.
+
+Des telles decisions peuvent être nécessaires dans le cas de perte des données d'accès, d'une nouvelle requête d'accès ou de retraite du référent précédent.</help>
+		<help lang="it">Esempi di tali decisioni: l'assegnazione di un conto o di diritti di accesso, la razionalizzazione dello spazio di archivio dopo una scadenza di conservazione definita, la trasmissione della sovranità a un'altra persona di riferimento.
+
+Tali decisioni possono essere necessarie in caso di perdita dei dati di accesso, di nuove richieste di accesso o di ritiro della persona di riferimento precedente.</help>
+		<text lang="fr">Qui est le référent pour toute décision en ce qui concerne les données sur le long terme&#8239;? Prière d'insérer un nom.</text>
+		<text lang="it">Chi è la persona di riferimento per tutte le decisioni relative ai dati nel lungo periodo? Si prega di inserire il nome.</text>
+		<verbose_name lang="fr"/>
+		<verbose_name lang="it"/>
+		<verbose_name_plural lang="fr"/>
+		<verbose_name_plural lang="it"/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<optionsets/>
+		<conditions/>
+	</question>
+	<question dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/storage-and-long-term-preservation/long-term-preservation-datasets/responsible_person_email">
+		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
+		<key>responsible_person_email</key>
+		<path>rdmo/storage-and-long-term-preservation/long-term-preservation-datasets/responsible_person_email</path>
+		<dc:comment/>
+		<attribute dc:uri="https://rdmorganiser.github.io/terms/domain/project/dataset/preservation/responsible_person/email"/>
+		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/storage-and-long-term-preservation/long-term-preservation-datasets"/>
+		<is_collection>False</is_collection>
+		<order>12</order>
+		<help lang="en"/>
+		<text lang="en">Please provide the email address of the permanent contact person named above.</text>
+		<verbose_name lang="en"/>
+		<verbose_name_plural lang="en"/>
+		<help lang="de"/>
+		<text lang="de">Bitte geben Sie die E-Mail-Adresse des oben genannten dauerhaften Ansprechpartners an.</text>
+		<verbose_name lang="de"/>
+		<verbose_name_plural lang="de"/>
+		<help lang="fr"/>
+		<help lang="it"/>
+		<text lang="fr">Prière d'insérer une adresse de courriel électronique du référent nommé ci-dessus.</text>
+		<text lang="it">Si prega di inserire l'indirizzo e-mail del referente nominato sopra.</text>
+		<verbose_name lang="fr"/>
+		<verbose_name lang="it"/>
+		<verbose_name_plural lang="fr"/>
+		<verbose_name_plural lang="it"/>
+		<widget_type>text</widget_type>
+		<value_type>text</value_type>
+		<maximum/>
+		<minimum/>
+		<step/>
+		<unit/>
+		<optionsets/>
+		<conditions/>
+	</question>
 	<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/rdmo/storage-and-long-term-preservation/long-term-preservation-costs">
 		<uri_prefix>https://rdmorganiser.github.io/terms</uri_prefix>
 		<key>long-term-preservation-costs</key>

--- a/tools/all_questions.xml
+++ b/tools/all_questions.xml
@@ -4309,14 +4309,19 @@ Weitere relevante Schutzrechte können gewerbliche Schutzrechte wie Patente, Geb
 		<questionset dc:uri="https://rdmorganiser.github.io/terms/questions/ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets"/>
 		<is_collection>False</is_collection>
 		<order>11</order>
-		<help lang="en">A similar question is, what happens if the access data is lost or, for example, if the chair holder retires? This should be taken into consideration later on by means of a workflow.</help>
-		<text lang="en">Who is the permanent project owner/data owner who can decide on the data after the researcher leaves? Please enter the name.</text>
+		<help lang="en">Examples of these decisions include data access and authorization, the optimization of storage space after a certain retention period, or the transfer of authority to a new contact person.
+
+Such decisions are necessary, for example, in the event of a loss of access data, a new access request or the departure of the previous contact person.</help>
+		<text lang="en">Who is the long-term contact person who can make decisions about the data? Please specify the name.</text>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
-		<help lang="de">Eine ähnliche Fragestellung ist, was passiert bei Verlust der Zugangsdaten oder beispielsweise beim Ausscheiden/Ruhestand des Lehrstuhlinhabers? Dies sollte später über einen Workflow mit bedacht werden.</help>
-		<text lang="de">Wer ist der dauerhafter Besitzer der Daten, der nach dem Weggang des Forschenden über die Daten entscheiden kann? Bitte geben Sie den Name an.</text>
+		<help lang="de">Beispiele hierfür sind die Vergabe von Zugangsdaten/Zugangsberechtigungen, die Optimierung des Speicherplatzes nach einer gewissen Aufbewahrungsfrist oder die Übergabe der Befugnisse an einen neuen Ansprechpartner.
+
+Solche Entscheidungen sind beispielsweise bei einem Verlust von Zugangsdaten, bei einer neuen Zugangsanfrage oder beim Ausscheiden des bisherigen Ansprechpartners erforderlich.</help>
+		<text lang="de">Wer ist der langfristige Ansprechpartner, der über die Daten entscheiden kann? Bitte geben Sie den Name an.</text>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
+		
 		<widget_type>text</widget_type>
 		<value_type>text</value_type>
 		<maximum/>
@@ -4336,13 +4341,21 @@ Weitere relevante Schutzrechte können gewerbliche Schutzrechte wie Patente, Geb
 		<is_collection>False</is_collection>
 		<order>12</order>
 		<help lang="en"/>
-		<text lang="en">Please provide the email address of the permanent owner of the data requested above.</text>
+		<text lang="en">Please provide the email address of the permanent contact person named above.</text>
 		<verbose_name lang="en"/>
 		<verbose_name_plural lang="en"/>
 		<help lang="de"/>
-		<text lang="de">Bitte geben Sie die E-Mail-Adresse des oben gefragten dauerhaften Besitzer der Daten an.</text>
+		<text lang="de">Bitte geben Sie die E-Mail-Adresse des oben genannten dauerhaften Ansprechpartners an.</text>
 		<verbose_name lang="de"/>
 		<verbose_name_plural lang="de"/>
+		<help lang="fr"/>
+		<help lang="it"/>
+		<text lang="fr">Prière d'insérer une adresse de courriel électronique du référent nommé ci-dessus.</text>
+		<text lang="it">Si prega di inserire l'indirizzo e-mail del referente nominato sopra.</text>
+		<verbose_name lang="fr"/>
+		<verbose_name lang="it"/>
+		<verbose_name_plural lang="fr"/>
+		<verbose_name_plural lang="it"/>
 		<widget_type>text</widget_type>
 		<value_type>text</value_type>
 		<maximum/>


### PR DESCRIPTION
To stay in sync with upstream (#111) we had to change the help text and question text of two questions:

- `https://rdmorganiser.github.io/terms/questions/ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/responsible_person_name` 
- `https://rdmorganiser.github.io/terms/questions/ua_ruhr/storage-and-long-term-preservation/long-term-preservation-datasets/responsible_person_email`

